### PR TITLE
add optional support for loading video library

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,8 @@ var Chartbeat = module.exports = integration('Chartbeat')
   .global('pSUPERFLY')
   .option('domain', '')
   .option('uid', null)
-  .tag('<script src="//static.chartbeat.com/js/chartbeat.js">');
+  .option('video', false)
+  .tag('<script src="//static.chartbeat.com/js/{{ script }}">');
 
 /**
  * Initialize.
@@ -30,16 +31,20 @@ var Chartbeat = module.exports = integration('Chartbeat')
 
 Chartbeat.prototype.initialize = function() {
   var self = this;
+  var script = this.options.video ? 'chartbeat_video.js' : 'chartbeat.js';
 
   window._sf_async_config = window._sf_async_config || {};
   window._sf_async_config.useCanonical = true;
-  defaults(window._sf_async_config, this.options);
+  defaults(window._sf_async_config, {
+    domain: this.options.domain,
+    uid: this.options.uid
+  });
 
   onBody(function() {
     window._sf_endpt = new Date().getTime();
     // Note: Chartbeat depends on document.body existing so the script does
     // not load until that is confirmed. Otherwise it may trigger errors.
-    self.load(self.ready);
+    self.load({ script: script }, self.ready);
   });
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,7 +11,8 @@ describe('Chartbeat', function() {
   var chartbeat;
   var options = {
     uid: 'x',
-    domain: 'example.com'
+    domain: 'example.com',
+    video: false
   };
 
   beforeEach(function() {
@@ -50,7 +51,12 @@ describe('Chartbeat', function() {
 
     describe('#initialize', function() {
       it('should create window._sf_async_config', function() {
-        var expected = extend({}, options, { useCanonical: true });
+        var expected = extend({}, {
+          uid: options.uid,
+          domain: options.domain
+        }, {
+          useCanonical: true
+        });
         analytics.initialize();
         analytics.page();
         analytics.deepEqual(window._sf_async_config, expected);
@@ -58,7 +64,7 @@ describe('Chartbeat', function() {
 
       it('should inherit global window._sf_async_config defaults', function() {
         window._sf_async_config = { setting: true };
-        var expected = extend({}, options, {
+        var expected = extend({}, { uid: options.uid, domain: options.domain }, {
           setting: true,
           useCanonical: true
         });
@@ -86,6 +92,21 @@ describe('Chartbeat', function() {
   describe('loading', function() {
     it('should load', function(done) {
       analytics.load(chartbeat, done);
+    });
+
+    it('should load regular lib when video is false', function() {
+      analytics.spy(chartbeat, 'load');
+      analytics.initialize();
+      analytics.page();
+      analytics.loaded('<script src="http://static.chartbeat.com/js/chartbeat.js">');
+    });
+
+    it('should load video lib when selected', function() {
+      chartbeat.options.video = true;
+      analytics.spy(chartbeat, 'load');
+      analytics.initialize();
+      analytics.page();
+      analytics.loaded('<script src="http://static.chartbeat.com/js/chartbeat_video.js">');
     });
   });
 


### PR DESCRIPTION
Chartbeat has a video library that offers a superset of functionality from their regular snippet — it can automatically listen for events from `<video>` players, etc. This adds support for that, allowing the user to opt-in to using the bigger video script should they choose.

http://support.chartbeat.com/docs/video.html#html5

**corresponding integration metadata update already done**

@ndhoule 
