### PR TITLE
Added framework for URL-change condition for virtualPage call

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,9 @@ var defaults = require('@ndhoule/defaults');
 var integration = require('@segment/analytics.js-integration');
 var onBody = require('on-body');
 
+/** TO-DO: connect urlChanged to Segment URL-change event **/
+var urlChanged = true;
+
 /**
  * Expose `Chartbeat` integration.
  */
@@ -20,6 +23,7 @@ var Chartbeat = module.exports = integration('Chartbeat')
   .option('uid', null)
   .option('video', false)
   .option('sendNameAndCategoryAsTitle', false)
+  .option('trackGalleryClicksAsPageviews', false)
   .option('subscriberEngagementKeys', [])
 
   .tag('<script src="//static.chartbeat.com/js/{{ script }}">');
@@ -58,7 +62,7 @@ Chartbeat.prototype.page = function(page) {
     this._ready = false;  // switch ready to false so that no pages after the first one can fire until _initialize has loaded chartbeat script
     this.pageCalledYet = true;
     this._initialize();
-  } else {
+  } else if (this.options.trackGalleryClicksAsPageviews || urlChanged) {
     var props = page.properties();
     window.pSUPERFLY.virtualPage(props.path);
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ Chartbeat.prototype.initialize = function() {
 
 Chartbeat.prototype.page = function(page) {
   this.updateConfig(page);
-  var urlChanged = this.currentURL !== window.location.href;
+  var urlChanged = this.currentURL !== window.location.pathname;
 
   // since chartbeat automatically calls a page when it loads, don't load chartbeat script until
   // first Segment page call comes in and configures global config vars using its props

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,9 +8,6 @@ var defaults = require('@ndhoule/defaults');
 var integration = require('@segment/analytics.js-integration');
 var onBody = require('on-body');
 
-/** TO-DO: connect urlChanged to Segment URL-change event **/
-var urlChanged = true;
-
 /**
  * Expose `Chartbeat` integration.
  */
@@ -41,6 +38,7 @@ Chartbeat.prototype.loaded = function() {
 
 Chartbeat.prototype.initialize = function() {
   this.pageCalledYet = false;
+  this.currentURL = window.location.href;
   this._ready = true; // temporarily switch ready to true so that a single page call can fire
 };
 
@@ -55,6 +53,7 @@ Chartbeat.prototype.initialize = function() {
 
 Chartbeat.prototype.page = function(page) {
   this.updateConfig(page);
+  var urlChanged = this.currentURL !== window.location.href;
 
   // since chartbeat automatically calls a page when it loads, don't load chartbeat script until
   // first Segment page call comes in and configures global config vars using its props


### PR DESCRIPTION
Created new `option` value for `trackGalleryClicksAsPageviews`, which should be added a toggle in the Segment UI. This creates an additional condition that only calls pSUPERFLY when the user has selected this toggle or if there has been an event that turned `urlChanged` to true.

TO-DO: 
- hook up `urlChanged` to an actual URL change event within segment architecture
- set up a new toggle in the UI that connects to `trackGalleryClicksAsPageviews`